### PR TITLE
Fix Travis builds and add new rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-#Mandrill DM
+
+# Mandrill DM
+
+[![Build Status](https://travis-ci.org/jlberglund/mandrill_dm.svg?branch=master)](https://travis-ci.org/jlberglund/mandrill_dm)
+[![Gem Version](https://badge.fury.io/rb/mandrill_dm.svg)](http://badge.fury.io/rb/mandrill_dm)
 
 Use Mandrill DM to use ActionMailer with the Mandrill API. Perfect for transitioning from Mandrill's SMTP service to their API.
 
-##  Rails Setup
+## Rails Setup
 
 First, add the gem to your Gemfile and run the `bundle` command to install it.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,27 @@
+require 'bundler'
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+Bundler.require(:default, :development)
+
+task default: :spec
+RSpec::Core::RakeTask.new
+
+directory 'tmp/coverage'
+desc 'Generates spec coverage results'
+task :coverage do
+  ENV['COVERAGE'] = '1'
+  Rake::Task[:spec].invoke
+  ENV['COVERAGE'] = nil
+  `open tmp/coverage/index.html` if RUBY_PLATFORM['darwin']
+end
+
+desc 'Validate Travis CI configuration'
+task :validate do
+  print ' Travis CI Validation '.center(80, '*') + "\n"
+  result = `travis-lint #{File.expand_path('../.travis.yml', __FILE__)}`
+  puts result.empty? ? 'OK' : result
+  print '*' * 80 + "\n"
+  raise 'Travis CI validation failed' unless result.empty?
+end
+

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -15,4 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mandrill-api', '~> 1.0.53'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'mail'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'travis-lint'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,28 @@
+require 'simplecov'
+SimpleCov.start do
+  coverage_dir 'tmp/coverage'
+  add_filter '/spec/'
+
+  SimpleCov.at_exit do
+    SimpleCov.result.format!
+    system('open tmp/coverage/index.html') if RUBY_PLATFORM['darwin']
+  end
+end if ENV['COVERAGE']
+
 require 'rubygems'
 require 'bundler/setup'
 Bundler.require(:default)
 
-require "mail"
+require 'mail'
 
 MandrillDm.configure do |config|
   config.api_key = '1234567890'
 end
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
 
-  config.before(:all) do 
+  config.before(:all) do
     Excon.defaults[:mock] = true
     Excon.stub({}, {body: '{}', status: 200}) # stubs any request to return an empty JSON string
   end


### PR DESCRIPTION
Add Rakefile (run `rake -T` to see new rake options)
- Add ‘rake’, ‘simplecov’, and 'travis-lint' gems as development dependencies.
- Add travis build status and gem version badges to README
- Add `bundler/gem_tasks` to Rakefile for gem releases (adds rake tasks)
- Add `rake coverage` - run specs/simplecov
- Add `rake spec` - run specs (like `rspec`) - needed for travis
- Add `rake validate` - validate travis-ci config
- remove deprecated treat_symbols_as_metadata_keys_with_true_values in spec_helper (defaults to true)
