### PR TITLE
Ensure keys with no value aren’t included in the API call to prevent overriding header options

### DIFF
--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -180,6 +180,7 @@ module MandrillDm
         X-MC-SigningDomain
         X-MC-Subaccount
         X-MC-Track
+        X-MC-Tags
         X-MC-TrackingDomain
         X-MC-URLStripQS
         X-MC-ViewContentLink

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -144,7 +144,7 @@ module MandrillDm
         tracking_domain: tracking_domain,
         url_strip_qs: url_strip_qs,
         view_content_link: view_content_link
-      }
+      }.reject { |key, value| value.nil? }
 
       attachment? ? json_hash.merge(attachments: attachments) : json_hash
     end
@@ -153,7 +153,9 @@ module MandrillDm
 
     # Returns an array of tags
     def collect_tags
-      mail[:tags].to_s.split(', ').map { |tag| tag }
+      if mail[:tags]
+        mail[:tags].to_s.split(', ').map { |tag| tag }
+      end
     end
 
     # Returns a single, flattened hash with all to, cc, and bcc addresses

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -521,7 +521,7 @@ describe MandrillDm::Message do
                       tags: 'test_tag')
       message = described_class.new(mail)
       expect(message.to_json).to(
-        include(:from_email, :from_name, :html, :subject, :to, :headers, :tags)
+        include(:from_email, :html, :to, :headers, :tags)
       )
     end
 
@@ -534,8 +534,22 @@ describe MandrillDm::Message do
 
       message = described_class.new(mail)
       expect(message.to_json).to(
-        include(:from_email, :from_name, :html, :subject, :to, :attachments)
+        include(:from_email, :html, :to, :attachments)
       )
+    end
+
+    context 'to prevent overriding header options X-Tags etc' do
+      let(:headers) {
+        { 'X-MC-ViewContentLink' => 'false', 'X-MC-Tags' => 'test,tag', 'X-MC-Track' => 'opens' }
+      }
+      let(:mail) { new_mail(body: 'test',
+                            from: 'name@domain.tld',
+                            headers: headers) }
+      subject(:message_json) { described_class.new(mail).to_json }
+
+      it { should_not have_key(:tags) }
+      it { should_not have_key(:view_content_link) }
+      it { should_not have_key(:track) }
     end
   end
 end


### PR DESCRIPTION
Fixes an issue where setting header options like `X-MC-Track`, `X-MC-Tags` and `X-MC-ViewContentLink` no longer work due to the nil values overriding them.
