### PR TITLE
add support for merge_vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
 - 1.9.3
 - 2.0

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -65,6 +65,10 @@ module MandrillDm
       return_string_value(:merge_language)
     end
 
+    def merge_vars
+      mail[:merge_vars] ? mail[:merge_vars].instance_variable_get("@value") : nil
+    end
+
     def preserve_recipients
       nil_true_false?(:preserve_recipients)
     end
@@ -131,6 +135,7 @@ module MandrillDm
         inline_css: inline_css,
         merge: merge,
         merge_language: merge_language,
+        merge_vars: merge_vars,
         preserve_recipients: preserve_recipients,
         return_path_domain: return_path_domain,
         signing_domain: signing_domain,

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -65,8 +65,10 @@ module MandrillDm
       return_string_value(:merge_language)
     end
 
+    # `mail[:merge_vars].value` returns the variables pre-processed,
+    # `instance_variable_get('@value')` returns them exactly as they were passed in
     def merge_vars
-      mail[:merge_vars] ? mail[:merge_vars].instance_variable_get("@value") : nil
+      mail[:merge_vars] ? mail[:merge_vars].instance_variable_get('@value') : nil
     end
 
     def preserve_recipients

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -76,6 +76,12 @@ module MandrillDm
       return_string_value(:merge_language)
     end
 
+    # `mail[:merge_vars].value` returns the variables pre-processed,
+    # `instance_variable_get('@value')` returns them exactly as they were passed in
+    def merge_vars
+      mail[:merge_vars] ? mail[:merge_vars].instance_variable_get("@value") : nil
+    end
+
     def preserve_recipients
       nil_true_false?(:preserve_recipients)
     end
@@ -142,6 +148,7 @@ module MandrillDm
         inline_css: inline_css,
         merge: merge,
         merge_language: merge_language,
+        merge_vars: merge_vars,
         preserve_recipients: preserve_recipients,
         return_path_domain: return_path_domain,
         signing_domain: signing_domain,

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -247,7 +247,11 @@ describe MandrillDm::Message do
 
   describe '#merge_vars' do
     it 'takes an array od merge_vars definitions' do
-      merge_vars = [ { 'rcpt' => 'a@a.de', 'vars' => [ { 'name' => 'MY_VAR', 'content' => 'foo' } ] } ]
+      vars = [
+        { 'name' => 'MY_VAR_1', 'content' => 'foo' },
+        { 'name' => 'MY_VAR_2', 'content' => 'bar' }
+      ]
+      merge_vars = [{ 'rcpt' => 'a@a.de', 'vars' => vars }]
       mail = new_mail(merge_vars: merge_vars)
       message = described_class.new(mail)
       expect(message.merge_vars).to eq(merge_vars)

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -284,7 +284,19 @@ describe MandrillDm::Message do
     end
   end
 
-  pending '#merge_vars'
+  describe '#merge_vars' do
+    it 'takes an array od merge_vars definitions' do
+      vars = [
+        { 'name' => 'MY_VAR_1', 'content' => 'foo' },
+        { 'name' => 'MY_VAR_2', 'content' => 'bar' }
+      ]
+      merge_vars = [ { 'rcpt' => 'a@a.de', 'vars' => vars } ]
+      mail = new_mail(merge_vars: merge_vars)
+      message = described_class.new(mail)
+      expect(message.merge_vars).to eq(merge_vars)
+    end
+  end
+
   pending '#metadata'
 
   describe '#preserve_recipients' do

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -245,7 +245,15 @@ describe MandrillDm::Message do
     end
   end
 
-  pending '#merge_vars'
+  describe '#merge_vars' do
+    it 'takes an array od merge_vars definitions' do
+      merge_vars = [ { 'rcpt' => 'a@a.de', 'vars' => [ { 'name' => 'MY_VAR', 'content' => 'foo' } ] } ]
+      mail = new_mail(merge_vars: merge_vars)
+      message = described_class.new(mail)
+      expect(message.merge_vars).to eq(merge_vars)
+    end
+  end
+
   pending '#metadata'
 
   describe '#preserve_recipients' do


### PR DESCRIPTION
see #17 

``` ruby
header[:merge_vars] = [ { rcpt: …, vars: [ { name: …, content: … } ] } ]
```

see also:
https://mandrill.zendesk.com/hc/en-us/articles/205582487-How-to-Use-Merge-Tags-to-Add-Dynamic-Content
