### PR TITLE
Add ruby 2.3 to travis, and tighten development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
+sudo: false
 rvm:
 - 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
 notifications:
   email:
     on_success: change

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -13,11 +13,10 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib,spec}/**/*', '[A-Z]*'] - ['Gemfile.lock']
   s.require_path = 'lib'
 
-  s.add_dependency 'mandrill-api', '~> 1.0.53'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'mail'
+  s.add_dependency 'mandrill-api',            '~> 1.0.53'
+  s.add_development_dependency 'rspec',       '~> 3.4'
+  s.add_development_dependency 'mail',        '~> 2.6'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'travis-lint'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'simplecov',   '~> 0.11'
+  s.add_development_dependency 'rubocop',     '~> 0.36'
 end


### PR DESCRIPTION
Make it easier for ensuring we have reproducible test results
- Add `sudo: false` to Travis to ensure we are using container build infrastructure.
- Remove `travis-lint` gem (wasn't a real dev dependency)
