### PR TITLE
Support send template

### DIFF
--- a/lib/mandrill_dm.rb
+++ b/lib/mandrill_dm.rb
@@ -1,6 +1,7 @@
 require 'mandrill'
 
 require 'mandrill_dm/message'
+require 'mandrill_dm/template'
 require 'mandrill_dm/delivery_method'
 require 'mandrill_dm/railtie' if defined? Rails
 

--- a/lib/mandrill_dm/delivery_method.rb
+++ b/lib/mandrill_dm/delivery_method.rb
@@ -8,23 +8,36 @@ module MandrillDm
 
     def deliver!(mail)
       mandrill_api = Mandrill::API.new(MandrillDm.configuration.api_key)
-
       template = Template.new(mail)
       message = Message.new(mail)
 
-      @response = if template.name
-                    mandrill_api.messages.send_template(
-                      template.name,
-                      template.content,
-                      message.to_json,
-                      MandrillDm.configuration.async
-                    )
-                  else
-                    mandrill_api.messages.send(
-                      message.to_json,
-                      MandrillDm.configuration.async
-                    )
-                  end
+      @response = mandrill_deliver(mandrill_api, template, message)
+    end
+
+  private
+
+    def mandrill_deliver(mandrill_api, template, message)
+      if template.name
+        send_template(mandrill_api, template, message)
+      else
+        send(mandrill_api, message)
+      end
+    end
+
+    def send(mandrill_api, message)
+      mandrill_api.messages.send(
+        message.to_json,
+        MandrillDm.configuration.async
+      )
+    end
+
+    def send_template(mandrill_api, template, message)
+      mandrill_api.messages.send_template(
+        template.name,
+        template.content,
+        message.to_json,
+        MandrillDm.configuration.async
+      )
     end
   end
 end

--- a/lib/mandrill_dm/delivery_method.rb
+++ b/lib/mandrill_dm/delivery_method.rb
@@ -8,11 +8,23 @@ module MandrillDm
 
     def deliver!(mail)
       mandrill_api = Mandrill::API.new(MandrillDm.configuration.api_key)
+
+      template = Template.new(mail)
       message = Message.new(mail)
-      @response = mandrill_api.messages.send(
-        message.to_json,
-        MandrillDm.configuration.async
-      )
+
+      @response = if template.name
+                    mandrill_api.messages.send_template(
+                      template.name,
+                      template.content,
+                      message.to_json,
+                      MandrillDm.configuration.async
+                    )
+                  else
+                    mandrill_api.messages.send(
+                      message.to_json,
+                      MandrillDm.configuration.async
+                    )
+                  end
     end
   end
 end

--- a/lib/mandrill_dm/template.rb
+++ b/lib/mandrill_dm/template.rb
@@ -12,7 +12,7 @@ module MandrillDm
 
     def content
       return [] unless mail[:template_content]
-      JSON.parse("[#{mail[:template_content].to_s.gsub('=>', ':')}]")
+      mail[:template_content].instance_variable_get('@value')
     end
   end
 end

--- a/lib/mandrill_dm/template.rb
+++ b/lib/mandrill_dm/template.rb
@@ -1,0 +1,18 @@
+module MandrillDm
+  class Template
+    attr_reader :mail
+
+    def initialize(mail)
+      @mail = mail
+    end
+
+    def name
+      mail[:template_name] ? mail[:template_name].to_s : nil
+    end
+
+    def content
+      return [] unless mail[:template_content]
+      JSON.parse("[#{mail[:template_content].to_s.gsub('=>', ':')}]")
+    end
+  end
+end

--- a/lib/mandrill_dm/template.rb
+++ b/lib/mandrill_dm/template.rb
@@ -6,8 +6,9 @@ module MandrillDm
       @mail = mail
     end
 
+    # ActionMailer is using the 'template_name', so we can't use it.
     def name
-      mail[:template_name] ? mail[:template_name].to_s : nil
+      mail[:template] ? mail[:template].to_s : nil
     end
 
     def content

--- a/spec/mandrill_dm/delivery_method_integration_spec.rb
+++ b/spec/mandrill_dm/delivery_method_integration_spec.rb
@@ -14,7 +14,7 @@ describe MandrillDm::DeliveryMethod, 'integrating with the Mail API', integratio
     let(:bcc)              { (1..3).map { |i| "Bcc #{i} <bcc_#{i}@domain.tld>" } }
     let(:message_subject)  { 'Some Message Subject' }
     let(:body)             { 'Some Message Body' }
-    let(:template_name)    { 'Test Template' }
+    let(:template)         { 'Test Template' }
     let(:template_content) { [{ 'name' => 'Some Name', 'content' => 'Some Content' }] }
 
     let(:api)      { instance_double(Mandrill::API) }
@@ -101,7 +101,7 @@ describe MandrillDm::DeliveryMethod, 'integrating with the Mail API', integratio
       subject do
         example = self
         new_mail(
-          template_name: example.template_name,
+          template: example.template,
           template_content: example.template_content,
           from: example.from,
           to: example.to,
@@ -125,7 +125,7 @@ describe MandrillDm::DeliveryMethod, 'integrating with the Mail API', integratio
 
       it 'contains the provided data' do
         expect(messages).to receive(:send_template).with(
-          template_name,
+          template,
           template_content,
           hash_including(subject: message_subject,
                          from_name: from_name,

--- a/spec/mandrill_dm/delivery_method_integration_spec.rb
+++ b/spec/mandrill_dm/delivery_method_integration_spec.rb
@@ -6,88 +6,132 @@ describe MandrillDm::DeliveryMethod, 'integrating with the Mail API', integratio
   end
 
   context '#deliver' do
-    let(:from_name)       { 'From Name' }
-    let(:from_email)      { 'from@domain.tld' }
-    let(:from)            { "#{from_name} <#{from_email}>" }
-    let(:to)              { (1..3).map { |i| "To #{i} <to_#{i}@domain.tld>" } }
-    let(:cc)              { (1..3).map { |i| "Cc #{i} <cc_#{i}@domain.tld>" } }
-    let(:bcc)             { (1..3).map { |i| "Bcc #{i} <bcc_#{i}@domain.tld>" } }
-    let(:message_subject) { 'Some Message Subject' }
-    let(:body)            { 'Some Message Body' }
+    let(:from_name)        { 'From Name' }
+    let(:from_email)       { 'from@domain.tld' }
+    let(:from)             { "#{from_name} <#{from_email}>" }
+    let(:to)               { (1..3).map { |i| "To #{i} <to_#{i}@domain.tld>" } }
+    let(:cc)               { (1..3).map { |i| "Cc #{i} <cc_#{i}@domain.tld>" } }
+    let(:bcc)              { (1..3).map { |i| "Bcc #{i} <bcc_#{i}@domain.tld>" } }
+    let(:message_subject)  { 'Some Message Subject' }
+    let(:body)             { 'Some Message Body' }
+    let(:template_name)    { 'Test Template' }
+    let(:template_content) { [{ 'name' => 'Some Name', 'content' => 'Some Content' }] }
 
     let(:api)      { instance_double(Mandrill::API) }
-    let(:messages) { instance_double(Mandrill::Messages, send: {}) }
+    let(:messages) { instance_double(Mandrill::Messages, send: {}, send_template: {}) }
 
     before(:each) do
       allow(Mandrill::API).to receive(:new).and_return(api)
       allow(api).to receive(:messages).and_return(messages)
     end
 
-    subject do
-      example = self
-      Mail.deliver do
-        from example.from
-        to example.to
-        cc example.cc
-        bcc example.bcc
-        subject example.message_subject
-        body example.body
+    context '#send' do
+      subject do
+        example = self
+        Mail.deliver do
+          from example.from
+          to example.to
+          cc example.cc
+          bcc example.bcc
+          subject example.message_subject
+          body example.body
+        end
       end
-    end
 
-    it 'instantiates the Mandrill API with the configured API key' do
-      expect(Mandrill::API).to(
-        receive(:new).with(MandrillDm.configuration.api_key).and_return(api)
-      )
-
-      subject
-    end
-
-    it 'successfully sends a message' do
-      allow(Mandrill::API).to receive(:new).and_call_original
-
-      expect { subject }.not_to raise_error
-    end
-
-    context 'the sent message' do
-      it 'contains the provided from address' do
-        expect(messages).to(
-          receive(:send).with(
-            hash_including(from_name: from_name, from_email: from_email), false
-          )
+      it 'instantiates the Mandrill API with the configured API key' do
+        expect(Mandrill::API).to(
+          receive(:new).with(MandrillDm.configuration.api_key).and_return(api)
         )
 
         subject
       end
 
-      %w(to cc bcc).each do |recipient_type|
-        it 'contains the provided #{recipient_type} addresses' do
-          expect(messages).to receive(:send) do |message_hash|
-            (1..3).each do |i|
-              expected_recipient = {
-                email: "#{recipient_type}_#{i}@domain.tld",
-                name:  "#{recipient_type.capitalize} #{i}",
-                type:  recipient_type
-              }
-              expect(message_hash[:to]).to include(expected_recipient)
+      it 'successfully sends a message' do
+        allow(Mandrill::API).to receive(:new).and_call_original
+
+        expect { subject }.not_to raise_error
+      end
+
+      context 'the sent message' do
+        it 'contains the provided from address' do
+          expect(messages).to(
+            receive(:send).with(
+              hash_including(from_name: from_name, from_email: from_email), false
+            )
+          )
+
+          subject
+        end
+
+        %w(to cc bcc).each do |recipient_type|
+          it 'contains the provided #{recipient_type} addresses' do
+            expect(messages).to receive(:send) do |message_hash|
+              (1..3).each do |i|
+                expected_recipient = {
+                  email: "#{recipient_type}_#{i}@domain.tld",
+                  name:  "#{recipient_type.capitalize} #{i}",
+                  type:  recipient_type
+                }
+                expect(message_hash[:to]).to include(expected_recipient)
+              end
             end
+
+            subject
           end
+        end
+
+        it 'contains the provided subject' do
+          expect(messages).to receive(:send).with(
+            hash_including(subject: message_subject),
+            false
+          )
+
+          subject
+        end
+
+        it 'contains the provided body as HTML' do
+          expect(messages).to receive(:send).with(hash_including(html: body), false)
 
           subject
         end
       end
+    end
 
-      it 'contains the provided subject' do
-        expect(messages).to receive(:send).with(
-          hash_including(subject: message_subject),
-          false
+    context '#send_template' do
+      subject do
+        example = self
+        new_mail(
+          template_name: example.template_name,
+          template_content: example.template_content,
+          from: example.from,
+          to: example.to,
+          subject: example.message_subject
+        ).deliver
+      end
+
+      it 'instantiates the Mandrill API with the configured API key' do
+        expect(Mandrill::API).to(
+          receive(:new).with(MandrillDm.configuration.api_key).and_return(api)
         )
 
         subject
       end
 
-      it 'contains the provided body as HTML' do
-        expect(messages).to receive(:send).with(hash_including(html: body), false)
+      it 'successfully sends a message' do
+        allow(Mandrill::API).to receive(:new).and_call_original
+
+        expect { subject }.not_to raise_error
+      end
+
+      it 'contains the provided data' do
+        expect(messages).to receive(:send_template).with(
+          template_name,
+          template_content,
+          hash_including(subject: message_subject,
+                         from_name: from_name,
+                         from_email: from_email),
+          false
+        )
 
         subject
       end

--- a/spec/mandrill_dm/delivery_method_spec.rb
+++ b/spec/mandrill_dm/delivery_method_spec.rb
@@ -15,9 +15,15 @@ describe MandrillDm::DeliveryMethod do
     let(:api_key)      { '1234567890' }
     let(:async)        { false }
     let(:dm_message)   { instance_double(MandrillDm::Message) }
-    let(:response)     { { 'some_response_key' => 'some response value' } }
-    let(:messages)     { instance_double(Mandrill::Messages, send: response) }
-    let(:api)          { instance_double(Mandrill::API, messages: messages) }
+    let(:dm_template)  { instance_double(MandrillDm::Template, name: nil, content: []) }
+    let(:response)     { { 'send_response_key' => 'send response value' } }
+    let(:response_st)  { { 'send_tmp_response_key' => 'send tmp response value' } }
+
+    let(:messages) do
+      instance_double(Mandrill::Messages, send: response, send_template: response_st)
+    end
+
+    let(:api) { instance_double(Mandrill::API, messages: messages) }
 
     before(:each) do
       allow(Mandrill::API).to receive(:new).and_return(api)
@@ -27,6 +33,7 @@ describe MandrillDm::DeliveryMethod do
       ).and_return(api_key)
       allow(MandrillDm).to receive_message_chain(:configuration, :async).and_return(async)
       allow(MandrillDm::Message).to receive(:new).and_return(dm_message)
+      allow(MandrillDm::Template).to receive(:new).and_return(dm_template)
     end
 
     subject { delivery_method.deliver!(mail_message) }
@@ -37,29 +44,63 @@ describe MandrillDm::DeliveryMethod do
       subject
     end
 
-    it 'creates a Mandrill message from the Mail message' do
-      expect(MandrillDm::Message).to(
-        receive(:new).with(mail_message).and_return(dm_message)
-      )
+    context '#send' do
+      it 'creates a Mandrill message from the Mail message' do
+        expect(MandrillDm::Message).to(
+          receive(:new).with(mail_message).and_return(dm_message)
+        )
 
-      subject
+        subject
+      end
+
+      it 'sends the JSON version of the Mandrill message via the API' do
+        allow(dm_message).to receive(:to_json).and_return('Some message JSON')
+        expect(messages).to receive(:send).with('Some message JSON', false)
+
+        subject
+      end
+
+      it 'returns the response from sending the message' do
+        expect(subject).to eql(response)
+      end
+
+      it 'establishes the response for subsequent use' do
+        subject
+
+        expect(delivery_method.response).to eql(response)
+      end
     end
 
-    it 'sends the JSON version of the Mandrill message via the API' do
-      allow(dm_message).to receive(:to_json).and_return('Some message JSON')
-      expect(messages).to receive(:send).with('Some message JSON', false)
+    context '#send_template' do
+      before(:each) do
+        allow(dm_template).to receive(:name).and_return('Test template')
+      end
 
-      subject
-    end
+      it 'creates a Mandrill message from the Mail message' do
+        expect(MandrillDm::Template).to(
+          receive(:new).with(mail_message).and_return(dm_template)
+        )
 
-    it 'returns the response from sending the message' do
-      expect(subject).to eql(response)
-    end
+        subject
+      end
 
-    it 'establishes the response for subsequent use' do
-      subject
+      it 'sends with template the JSON version of the Mandrill message via the API' do
+        allow(dm_message).to receive(:to_json).and_return('Some message JSON')
+        expect(messages).to receive(:send_template)
+          .with(dm_template.name, dm_template.content, 'Some message JSON', false)
 
-      expect(delivery_method.response).to eql(response)
+        subject
+      end
+
+      it 'returns the response from sending the message' do
+        expect(subject).to eql(response_st)
+      end
+
+      it 'establishes the response for subsequent use' do
+        subject
+
+        expect(delivery_method.response).to eql(response_st)
+      end
     end
   end
 end

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe MandrillDm::Message do
-  def new_mail(options = {}, &blk)
-    Mail.new(options, &blk)
-  end
-
   describe '#attachments' do
     it 'takes an attachment' do
       mail = new_mail(to: 'name@domain.tld', content_type: 'multipart/alternative')

--- a/spec/mandrill_dm/template_spec.rb
+++ b/spec/mandrill_dm/template_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe MandrillDm::Template do
+  describe '#name' do
+    it 'takes a template_name with true' do
+      mail = new_mail(template_name: 'test template name')
+      template = described_class.new(mail)
+      expect(template.name).to eq('test template name')
+    end
+
+    it 'does not take an template_name value' do
+      mail = new_mail
+      template = described_class.new(mail)
+      expect(template.name).to be_nil
+    end
+  end
+
+  describe '#content' do
+    it 'takes an array of template_content' do
+      template_content = [
+        {
+          'name' => 'test name',
+          'content' => 'test content'
+        }
+      ]
+      mail = new_mail(template_content: template_content)
+      template = described_class.new(mail)
+      expect(template.content).to eq(template_content)
+    end
+
+    it 'does not take template_content value' do
+      mail = new_mail
+      template = described_class.new(mail)
+      expect(template.content).to eq([])
+    end
+  end
+end

--- a/spec/mandrill_dm/template_spec.rb
+++ b/spec/mandrill_dm/template_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe MandrillDm::Template do
   describe '#name' do
-    it 'takes a template_name with true' do
-      mail = new_mail(template_name: 'test template name')
+    it 'takes a template with true' do
+      mail = new_mail(template: 'test template name')
       template = described_class.new(mail)
       expect(template.name).to eq('test template name')
     end
 
-    it 'does not take an template_name value' do
+    it 'does not take an template value' do
       mail = new_mail
       template = described_class.new(mail)
       expect(template.name).to be_nil

--- a/spec/mandrill_dm/template_spec.rb
+++ b/spec/mandrill_dm/template_spec.rb
@@ -17,12 +17,7 @@ describe MandrillDm::Template do
 
   describe '#content' do
     it 'takes an array of template_content' do
-      template_content = [
-        {
-          'name' => 'test name',
-          'content' => 'test content'
-        }
-      ]
+      template_content = [{ 'name' => 'test name', 'content' => 'test content' }]
       mail = new_mail(template_content: template_content)
       template = described_class.new(mail)
       expect(template.content).to eq(template_content)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,3 +28,7 @@ RSpec.configure do |config|
     Excon.stub({}, body: '{}', status: 200)
   end
 end
+
+def new_mail(options = {}, &blk)
+  Mail.new(options, &blk)
+end


### PR DESCRIPTION
Hi @spovich @jlberglund @kshnurov,

I created a support for send template, because we would like to use it. It looks like somebody was faster than me, but I did this a little bit different way. And I would like to start a conversation about how can we support the `template_name template_content async ip_pool send_at`. I think to store these things in the `Message` class will not be the right place, but it would be great that I can setup it when I call the mail method. That's why I created a new `Template` class for it. But how about that rename it and call `SendOptions` or something similar and there we can reach these things.

And I was thinking about the async setup as well. So my problem the present setup that I can choose, it will send all the emails via async or not, but it would be better if I can choose these emails will send with async and those ones with normal mode in the mail method. Maybe I'm not right, but we could discuss it.
