### PR TITLE
Use JSON.parse because of the instance_variable_get issue on old mail

### DIFF
--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -216,10 +216,10 @@ module MandrillDm
     end
 
     # Returns an array of values e.g. merge_vars or gobal_merge_vars
-    # `mail[:merge_vars].value` returns the variables pre-processed,
-    # `instance_variable_get('@value')` returns them exactly as they were passed in
     def get_value(field)
-      mail[field] ? mail[field].instance_variable_get('@value') : nil
+      return nil unless mail[field]
+      value = mail[field].to_s.gsub(/:(\w+)/, '"\\1"').gsub('=>', ':')
+      JSON.parse("[#{value}]")
     end
 
     # Returns a Mandrill API compatible email address hash

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -218,7 +218,7 @@ module MandrillDm
     # Returns an array of values e.g. merge_vars or gobal_merge_vars
     def get_value(field)
       return nil unless mail[field]
-      value = mail[field].to_s.gsub(/:(\w+)/, '"\\1"').gsub('=>', ':')
+      value = mail[field].to_s.gsub(/:([a-z_]+)/, '"\\1"').gsub('=>', ':')
       JSON.parse("[#{value}]")
     end
 


### PR DESCRIPTION
Hi,

I changed instance_variable_get to JSON.parse that mandrill_dm can be compatible with the older mail versions. Issue reported here [#31](https://github.com/spovich/mandrill_dm/issues/31)
