### PR TITLE
Expose sent emails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,5 +22,5 @@ task :validate do
   result = `travis-lint #{File.expand_path('../.travis.yml', __FILE__)}`
   puts result.empty? ? 'OK' : result
   print '*' * 80 + "\n"
-  fail 'Travis CI validation failed' unless result.empty?
+  raise 'Travis CI validation failed' unless result.empty?
 end

--- a/lib/mandrill_dm/delivery_method.rb
+++ b/lib/mandrill_dm/delivery_method.rb
@@ -1,5 +1,8 @@
 module MandrillDm
   class DeliveryMethod
+    @deliveries = []
+    class << self; attr_reader :deliveries; end
+
     attr_accessor :settings, :response
 
     def initialize(options = {})
@@ -9,6 +12,7 @@ module MandrillDm
     def deliver!(mail)
       mandrill_api = Mandrill::API.new(MandrillDm.configuration.api_key)
       message = Message.new(mail)
+      self.class.deliveries << mail
       @response = mandrill_api.messages.send(
         message.to_json,
         MandrillDm.configuration.async

--- a/spec/mandrill_dm/delivery_method_spec.rb
+++ b/spec/mandrill_dm/delivery_method_spec.rb
@@ -61,5 +61,10 @@ describe MandrillDm::DeliveryMethod do
 
       expect(delivery_method.response).to eql(response)
     end
+
+    it 'adds sent email to MandrillDm::DeliveryMethod.deliveries' do
+      expect { subject }.to change { MandrillDm::DeliveryMethod.deliveries.size }.by(1)
+      expect(MandrillDm::DeliveryMethod.deliveries.last).to be(mail_message)
+    end
   end
 end

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -587,7 +587,7 @@ describe MandrillDm::Message do
     end
   end
 
-  describe '#url_strip_qs'do
+  describe '#url_strip_qs' do
     it 'takes a url_strip_qs with true' do
       mail = new_mail(url_strip_qs: true)
       message = described_class.new(mail)


### PR DESCRIPTION
`MandrillDm.DeliveryMethod.deliveries` returns sent emails. This allows to test if your code properly changed deliveries size (similar to `ApplicationMailer.deliveries.size` and `ApplicationMailer.deliveries.last`)
