### PR TITLE
Fix sending only text email.

### DIFF
--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -61,7 +61,11 @@ module MandrillDm
     end
 
     def html
-      mail.html_part ? mail.html_part.body.decoded : mail.body.decoded
+      if mail.html_part
+        mail.html_part.body.decoded
+      elsif !mail.text?
+        mail.body.decoded
+      end
     end
 
     def template
@@ -117,8 +121,11 @@ module MandrillDm
     end
 
     def text
-      return mail.text_part.body.decoded if mail.multipart? && mail.text_part
-      nil
+      if mail.multipart? && mail.text_part
+        mail.text_part.body.decoded
+      elsif mail.text?
+        mail.body.decoded
+      end
     end
 
     def to

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -61,11 +61,8 @@ module MandrillDm
     end
 
     def html
-      if mail.html_part
-        mail.html_part.body.decoded
-      elsif !mail.text?
-        mail.body.decoded
-      end
+      return mail.html_part.body.decoded if mail.html_part
+      return mail.body.decoded unless mail.text?
     end
 
     def template
@@ -121,11 +118,8 @@ module MandrillDm
     end
 
     def text
-      if mail.multipart? && mail.text_part
-        mail.text_part.body.decoded
-      elsif mail.text?
-        mail.body.decoded
-      end
+      return mail.text_part.body.decoded if mail.multipart? && mail.text_part
+      return mail.body.decoded if mail.text?
     end
 
     def to

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov',   '~> 0.11'
   s.add_development_dependency 'rubocop',     '~> 0.36'
+  s.add_development_dependency 'mime-types',  '~> 2'
 end

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov',   '~> 0.11'
   s.add_development_dependency 'rubocop',     '~> 0.36'
-  s.add_development_dependency 'mime-types',  '~> 2'
 end

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -212,6 +212,13 @@ describe MandrillDm::Message do
       message = described_class.new(mail)
       expect(message.html).to eq('<html><body>Hello world!</body></html>')
     end
+
+
+    it 'does not takes a text message' do
+      mail = new_mail(to: 'name@domain.tld', body: 'Hello world!', content_type: 'text/plain')
+      message = described_class.new(mail)
+      expect(message.html).to eq(nil)
+    end
   end
 
   describe '#images' do
@@ -453,6 +460,12 @@ describe MandrillDm::Message do
       mail = new_mail(to: 'name@domain.tld', body: 'Hello world!')
       message = described_class.new(mail)
       expect(message.text).to eq(nil)
+    end
+
+    it 'takes a text message' do
+      mail = new_mail(to: 'name@domain.tld', body: 'Hello world!', content_type: 'text/plain')
+      message = described_class.new(mail)
+      expect(message.text).to eq('Hello world!')
     end
 
     it 'takes a multipart message' do

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -213,9 +213,12 @@ describe MandrillDm::Message do
       expect(message.html).to eq('<html><body>Hello world!</body></html>')
     end
 
-
     it 'does not takes a text message' do
-      mail = new_mail(to: 'name@domain.tld', body: 'Hello world!', content_type: 'text/plain')
+      mail = new_mail(
+        to: 'name@domain.tld',
+        body: 'Hello world!',
+        content_type: 'text/plain'
+      )
       message = described_class.new(mail)
       expect(message.html).to eq(nil)
     end
@@ -463,7 +466,11 @@ describe MandrillDm::Message do
     end
 
     it 'takes a text message' do
-      mail = new_mail(to: 'name@domain.tld', body: 'Hello world!', content_type: 'text/plain')
+      mail = new_mail(
+        to: 'name@domain.tld',
+        body: 'Hello world!',
+        content_type: 'text/plain'
+      )
       message = described_class.new(mail)
       expect(message.text).to eq('Hello world!')
     end


### PR DESCRIPTION
Hi

I found that there is a problem with sending emails that only have text format templates (foo.text.erb).
Previously it was sending pure text as html and mandril converted this "html" into text. After those transformations all formatting was gone.

PR fixes this.
