### PR TITLE
Make `rake` run all specs and rubocop checks. Remove ruby 1.9.3 from build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: ruby
 sudo: false
 rvm:
-- 1.9.3
-- 2.0
-- 2.1
-- 2.2
-- 2.3.0
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3.0
 notifications:
   email:
     on_success: change
     on_failure: always
 script:
-- bundle exec rubocop
-- bundle exec rake spec
+  - bundle exec rake

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class MyMailer < ActionMailer::Base
       template_content: [ # optional
         {
           name: 'header',
-          content: 'string to replace a *|header|* in your template', 
+          content: 'string to replace a *|header|* in your template',
         },
         {
           name: 'content',
@@ -72,6 +72,7 @@ end
 
 ## Development & Feedback
 
-Questions or problems? Please use the issue tracker. If you would like to contribute to this project, fork this repository. Pull requests appreciated.
+Questions or problems? Please use the issue tracker. If you would like to contribute to this project, fork this repository. Pull requests appreciated! Please ensure all specs and rubocop checks pass locally (run `rake`) and
+verify the travis build matrix passes.
 
 This gem was inspired by the [letter_opener](https://github.com/ryanb/letter_opener/) and [mandrill-delivery-handler](https://github.com/earnold/mandrill-delivery-handler) gems. Special thanks to the folks at MailChimp and Mandrill for their Starter service and [Ruby API](https://bitbucket.org/mailchimp/mandrill-api-ruby).

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,20 @@
 require 'bundler'
 require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
-
 Bundler.require(:default, :development)
 
-task default: :spec
+require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+task default: %w(all_checks)
+
+desc 'Run all specs and rubocop checks'
+task :all_checks do
+  Rake::Task['spec'].invoke
+  Rake::Task['rubocop'].invoke
+end
 
 directory 'tmp/coverage'
 desc 'Generates spec coverage results'


### PR DESCRIPTION
- Update README on PR’s for specs and rubocop
- Remove ruby 1.9.3 from Travis build matrix.
