### PR TITLE
Fix the problem when we have just an html part but showed up as text

### DIFF
--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -277,7 +277,6 @@ module MandrillDm
     end
 
     def html_content?
-      return true if mail.content_type.nil?
       mail.content_type =~ %r{text/html} ? true : false
     end
 

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -277,11 +277,11 @@ module MandrillDm
     end
 
     def html_content?
-      mail.content_type =~ %r{text/html} ? true : false
+      mail.content_type =~ %r{\btext/html\b} ? true : false
     end
 
     def text_content?
-      mail.content_type =~ %r{text/plain} ? true : false
+      mail.content_type =~ %r{\btext/plain\b} ? true : false
     end
 
     def return_string_value(field)

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -277,11 +277,11 @@ module MandrillDm
     end
 
     def html_content?
-      mail.content_type =~ %r{\btext/html\b} ? true : false
+      mail.mime_type == 'text/html' ? true : false
     end
 
     def text_content?
-      mail.content_type =~ %r{\btext/plain\b} ? true : false
+      mail.mime_type == 'text/plain' ? true : false
     end
 
     def return_string_value(field)

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -62,7 +62,7 @@ module MandrillDm
 
     def html
       return mail.html_part.body.decoded if mail.html_part
-      return mail.body.decoded unless mail.text?
+      html_content? ? mail.body.decoded : nil
     end
 
     def template
@@ -137,8 +137,8 @@ module MandrillDm
     end
 
     def text
-      return mail.text_part.body.decoded if mail.multipart? && mail.text_part
-      return mail.body.decoded if mail.text?
+      return mail.text_part.body.decoded if mail.text_part
+      text_content? ? mail.body.decoded : nil
     end
 
     def to
@@ -274,6 +274,15 @@ module MandrillDm
 
     def inline_attachments?
       mail.attachments.any?(&:inline?)
+    end
+
+    def html_content?
+      return true if mail.content_type.nil?
+      mail.content_type =~ %r{text/html} ? true : false
+    end
+
+    def text_content?
+      mail.content_type =~ %r{text/plain} ? true : false
     end
 
     def return_string_value(field)

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -62,7 +62,7 @@ module MandrillDm
 
     def html
       return mail.html_part.body.decoded if mail.html_part
-      html_content? ? mail.body.decoded : nil
+      return_decoded_body('text/html')
     end
 
     def template
@@ -138,7 +138,7 @@ module MandrillDm
 
     def text
       return mail.text_part.body.decoded if mail.text_part
-      text_content? ? mail.body.decoded : nil
+      return_decoded_body('text/plain')
     end
 
     def to
@@ -276,12 +276,8 @@ module MandrillDm
       mail.attachments.any?(&:inline?)
     end
 
-    def html_content?
-      mail.mime_type == 'text/html' ? true : false
-    end
-
-    def text_content?
-      mail.mime_type == 'text/plain' ? true : false
+    def return_decoded_body(mime_type)
+      mail.mime_type == mime_type ? mail.body.decoded : nil
     end
 
     def return_string_value(field)

--- a/spec/mandrill_dm/delivery_method_integration_spec.rb
+++ b/spec/mandrill_dm/delivery_method_integration_spec.rb
@@ -14,6 +14,7 @@ describe MandrillDm::DeliveryMethod, 'integrating with the Mail API', integratio
     let(:bcc)             { (1..3).map { |i| "Bcc #{i} <bcc_#{i}@domain.tld>" } }
     let(:message_subject) { 'Some Message Subject' }
     let(:body)            { 'Some Message Body' }
+    let(:content_type)    { 'text/html' }
 
     let(:api)      { instance_double(Mandrill::API) }
     let(:messages) { instance_double(Mandrill::Messages, send: {}) }
@@ -32,6 +33,7 @@ describe MandrillDm::DeliveryMethod, 'integrating with the Mail API', integratio
         bcc example.bcc
         subject example.message_subject
         body example.body
+        content_type example.content_type
       end
     end
 

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -187,7 +187,8 @@ describe MandrillDm::Message do
     it 'takes a non-multipart message' do
       mail = new_mail(
         to: 'name@domain.tld',
-        body: '<html><body>Hello world!</body></html>'
+        body: '<html><body>Hello world!</body></html>',
+        content_type: 'text/html'
       )
 
       message = described_class.new(mail)

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -234,7 +234,7 @@ describe MandrillDm::Message do
       message = described_class.new(mail)
       expect(message.html).to eq(nil)
     end
-    
+
     it 'takes with more thing in the content type' do
       mail = new_mail(
         to: 'name@domain.tld',
@@ -545,7 +545,7 @@ describe MandrillDm::Message do
       )
 
       message = described_class.new(mail)
-      expect(message.html).to eq('Hello world!')
+      expect(message.text).to eq('Hello world!')
     end
 
     it 'takes a text message' do

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -223,6 +223,17 @@ describe MandrillDm::Message do
       message = described_class.new(mail)
       expect(message.html).to eq(nil)
     end
+
+    it 'does not take a with the wrong content type' do
+      mail = new_mail(
+        to: 'name@domain.tld',
+        body: '<html><body>Hello world!</body></html>',
+        content_type: 'anytext/html5'
+      )
+
+      message = described_class.new(mail)
+      expect(message.html).to eq(nil)
+    end
   end
 
   describe '#images' do
@@ -500,6 +511,17 @@ describe MandrillDm::Message do
   describe '#text' do
     it 'does not take a non-multipart message' do
       mail = new_mail(to: 'name@domain.tld', body: 'Hello world!')
+      message = described_class.new(mail)
+      expect(message.text).to eq(nil)
+    end
+
+    it 'does not take a with the wrong content type' do
+      mail = new_mail(
+        to: 'name@domain.tld',
+        body: 'Hello world!',
+        content_type: 'anytext/plain'
+      )
+
       message = described_class.new(mail)
       expect(message.text).to eq(nil)
     end

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -234,6 +234,17 @@ describe MandrillDm::Message do
       message = described_class.new(mail)
       expect(message.html).to eq(nil)
     end
+    
+    it 'takes with more thing in the content type' do
+      mail = new_mail(
+        to: 'name@domain.tld',
+        body: '<html><body>Hello world!</body></html>',
+        content_type: 'text/html; charset="us-ascii"'
+      )
+
+      message = described_class.new(mail)
+      expect(message.html).to eq('<html><body>Hello world!</body></html>')
+    end
   end
 
   describe '#images' do
@@ -524,6 +535,17 @@ describe MandrillDm::Message do
 
       message = described_class.new(mail)
       expect(message.text).to eq(nil)
+    end
+
+    it 'takes with more thing in the content type' do
+      mail = new_mail(
+        to: 'name@domain.tld',
+        body: 'Hello world!',
+        content_type: 'text/plain; charset="us-ascii"'
+      )
+
+      message = described_class.new(mail)
+      expect(message.html).to eq('Hello world!')
     end
 
     it 'takes a text message' do

--- a/spec/mandrill_dm/message_spec.rb
+++ b/spec/mandrill_dm/message_spec.rb
@@ -224,7 +224,7 @@ describe MandrillDm::Message do
       expect(message.html).to eq(nil)
     end
 
-    it 'does not take a with the wrong content type' do
+    it 'does not take with the wrong content type' do
       mail = new_mail(
         to: 'name@domain.tld',
         body: '<html><body>Hello world!</body></html>',
@@ -515,7 +515,7 @@ describe MandrillDm::Message do
       expect(message.text).to eq(nil)
     end
 
-    it 'does not take a with the wrong content type' do
+    it 'does not take with the wrong content type' do
       mail = new_mail(
         to: 'name@domain.tld',
         body: 'Hello world!',


### PR DESCRIPTION
This PR is a patch for #44 issue

The problem was that on Rails if we have mailer with just an html content, than we got this message as a plain text and not html. The `mail.text?` at this case was `true` what is not definitely not true. It looks like under Rails `mail.text?` is always true if not multipart.
