### PR TITLE
Information about blank body param necessary for Mandrill templates in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Option     | Default value     | Description
 
 ### Mandrill Templates
 
-If you want to use this gem with mandrill templates you just have to add the `template` param to the `mail` function.
+If you want to use this gem with mandrill templates you just have to add the `template` param to the `mail` function and set the `body` param to empty string `''`.
 
 > We use `template` instead of `template_name` as described in mandrill documentation since `template_name` it's used by [ActionMailer](http://api.rubyonrails.org/classes/ActionMailer/Base.html).
 
@@ -54,6 +54,7 @@ class MyMailer < ActionMailer::Base
     mail(
       to: email,
       from: 'your@email.com',
+      body: '',
       template: 'your-mandrill-template-slug',
       template_content: [ # optional
         {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://travis-ci.org/spovich/mandrill_dm.svg?branch=master)](https://travis-ci.org/spovich/mandrill_dm)
 [![Gem Version](https://badge.fury.io/rb/mandrill_dm.svg)](http://badge.fury.io/rb/mandrill_dm)
 [![security](https://hakiri.io/github/spovich/mandrill_dm/master.svg)](https://hakiri.io/github/spovich/mandrill_dm/master)
+[![Code Climate](https://codeclimate.com/github/spovich/mandrill_dm/badges/gpa.svg)](https://codeclimate.com/github/spovich/mandrill_dm)
 
 Mandrill DM allows you to use ActionMailer with the Mandrill API. Created by [Jonathan Berglund](https://github.com/jlberglund)
 and maintained by [John Dell](https://github.com/spovich), and [Kirill Shnurov](https://github.com/kshnurov) and various [contributors](https://github.com/spovich/mandrill_dm/graphs/contributors).


### PR DESCRIPTION
Add information about the need to set `body = ''` in `#mail` when using templates stored in Mandrill.

re: https://github.com/spovich/mandrill_dm/issues/46