### PR TITLE
Move mail gem to runtime dependencies

### DIFF
--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.0'
 
+  s.add_dependency 'mail',                    '~> 2.6'
   s.add_dependency 'mandrill-api',            '~> 1.0.53'
 
   s.add_development_dependency 'rspec',       '~> 3.4'
-  s.add_development_dependency 'mail',        '~> 2.6'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov',   '~> 0.11'
   s.add_development_dependency 'rubocop',     '~> 0.40'


### PR DESCRIPTION
I noticed, that `mail` gem is declared as a development dependency, but actually `mandrill_dm` gem doesn't make sense without it in runtime. It means, if you bundle some app with gems, that don't have `mail` gem as a dependency by themselves (like `rails`), you will get error. So when you declare gem as a runtime dependency, it will be automatically placed to the `default` bundler group and accessible out of the box.