### PR TITLE
Set mail >= 2.6, rspec 3.7.x, and rubocop 0.50.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
-Style/AccessModifierIndentation:
-  EnforcedStyle: outdent
+AllCops:
+  TargetRubyVersion: 2.0
 
-Metrics/LineLength:
-  Max: 90
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
 
 Metrics/BlockLength:
   CountComments: false
@@ -11,6 +11,9 @@ Metrics/BlockLength:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+
+Metrics/LineLength:
+  Max: 90
 
 Style/Documentation:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.3.5 (2017-12-30)
+
+- [#55](https://github.com/spovich/mandrill_dm/pull/60) Add support for mail 2.7, thanks @tensho
+
 ### 1.3.4 (2017-05-28)
 
 - [#55](https://github.com/spovich/mandrill_dm/pull/55) Set default ip pool and override with each message, thanks @dorongutman

--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -76,7 +76,7 @@ module MandrillDm
     end
 
     def important
-      mail[:important].to_s == 'true' ? true : false
+      mail[:important].to_s == 'true'
     end
 
     def inline_css
@@ -231,7 +231,13 @@ module MandrillDm
     # `mail[:merge_vars].value` returns the variables pre-processed,
     # `instance_variable_get('@value')` returns them exactly as they were passed in
     def get_value(field)
-      mail[field] ? mail[field].instance_variable_get('@value') : nil
+      return nil unless mail[field]
+
+      if mail[field].instance_variable_defined?('@unparsed_value')
+        mail[field].instance_variable_get('@unparsed_value') # mail gem 2.7+
+      else
+        mail[field].instance_variable_get('@value') # mail gem <= 2.6
+      end
     end
 
     # Returns a Mandrill API compatible email address hash

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'mail',                    '~> 2.6'
+  s.add_dependency 'mail',                    '>= 2.6'
   s.add_dependency 'mandrill-api',            '~> 1.0.53'
 
-  s.add_development_dependency 'rspec',       '~> 3.4'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'simplecov',   '~> 0.13'
-  s.add_development_dependency 'rubocop',     '~> 0.47'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec',       '~> 3.7.0'
+  s.add_development_dependency 'rubocop',     '0.50.0'
+  s.add_development_dependency 'simplecov',   '~> 0.15.1'
 end

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'mandrill_dm'
-  s.version = '1.3.4'
-  s.date = '2017-05-28'
+  s.version = '1.3.5'
+  s.date = '2017-12-30'
   s.summary = 'A basic Mandrill delivery method for Rails.'
   s.description = 'A basic Mandrill delivery method for Rails.'
   s.authors = ['Jonathan Berglund', 'John Dell', 'Kirill Shnurov']

--- a/spec/mandrill_dm/delivery_method_integration_spec.rb
+++ b/spec/mandrill_dm/delivery_method_integration_spec.rb
@@ -66,7 +66,7 @@ describe MandrillDm::DeliveryMethod, 'integrating with the Mail API', integratio
       end
 
       %w[to cc bcc].each do |recipient_type|
-        it 'contains the provided #{recipient_type} addresses' do
+        it "contains the provided #{recipient_type} addresses" do
           expect(messages).to receive(:send) do |message_hash|
             (1..3).each do |i|
               expected_recipient = {


### PR DESCRIPTION
Update to handle both mail `2.6.x` and mail `2.7.x`.  Mail version `2.7.0` updated mail field `@value` to `@unparsed_value`.

Pin rubocop to exactly `0.50.0` (last version supporting ruby 2.0) to avoid future build failures when rubocop is updated. Fix rubocop violations for `0.50.0`

Signed-off-by: John Dell <john@mutations.ltd>