### PR TITLE
use mandrill-api-json gem as it uses a patched version of json gem bu…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ rvm:
   - 2.3
   - 2.4
   - 2.5.0
-before_install:
-  - gem update --system # fix ruby 2.5 travis build issue
 gemfile:
   - gemfiles/mail_2.6.gemfile
   - gemfiles/mail_2.7_0.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.3.7 (unreleased)
+
+- [#66](https://github.com/spovich/mandrill_dm/pull/66) Switch to security-patched fork of mandrill-api gem (mandrill-api-json). Patches CVE-2020-10663.
+
 ### 1.3.6 (2018-10-19)
 
 - [#63](https://github.com/spovich/mandrill_dm/pull/63) Adopt Mail::Field#unparsed_value public API, thanks @tensho

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -13,13 +13,13 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'mail',                    '>= 2.6'
-  s.add_dependency 'mandrill-api-json',            '~> 1.0.54'
+  s.add_dependency 'mail', '>= 2.6'
+  s.add_dependency 'mandrill-api-json', '~> 1.0.54'
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec',       '~> 3.7.0'
-  s.add_development_dependency 'rubocop',     '0.50.0'
-  s.add_development_dependency 'simplecov',   '~> 0.15.1'
+  s.add_development_dependency 'rspec', '~> 3.7.0'
+  s.add_development_dependency 'rubocop', '0.50.0'
+  s.add_development_dependency 'simplecov', '~> 0.15.1'
   s.add_development_dependency 'appraisal'
 end

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'mandrill_dm'
-  s.version = '1.3.6'
-  s.date = '2018-10-19'
+  s.version = '1.3.7'
+  s.date = '2020-03-20'
   s.summary = 'A basic Mandrill delivery method for Rails.'
   s.description = 'A basic Mandrill delivery method for Rails.'
   s.authors = ['Jonathan Berglund', 'John Dell', 'Kirill Shnurov']

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
 
   s.add_dependency 'mail',                    '>= 2.6'
-  s.add_dependency 'mandrill-api',            '~> 1.0.53'
+  s.add_dependency 'mandrill-api-json',            '~> 1.0.54'
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
…t is otherwise identical to mandrill-api gem

As per : https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/ the `json` gem used is insecure. It is a dependency of the `mandrill-api` gem, which hasn't been updated in years.

There is a forked version `mandrill-api-json` which supports a patched version of `json` and is also available as a ruby gem. The only difference, other than the name, is the version of `json` supported.